### PR TITLE
Fix language detection on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,37 @@
+# Sources
+*.c     text diff=c
+*.cc    text diff=cpp
+*.cxx   text diff=cpp
+*.cpp   text diff=cpp
+*.c++   text diff=cpp
+*.hpp   text diff=cpp
+*.h     text diff=c
+*.h++   text diff=cpp
+*.hh    text diff=cpp
+
+# Compiled Object files
+*.slo   binary
+*.lo    binary
+*.o     binary
+*.obj   binary
+
+# Precompiled Headers
+*.gch   binary
+*.pch   binary
+
+# Compiled Dynamic libraries
+*.so    binary
+*.dylib binary
+*.dll   binary
+
+# Compiled Static libraries
+*.lai   binary
+*.la    binary
+*.a     binary
+*.lib   binary
+
+# Executables
+*.exe   binary
+*.out   binary
+*.app   binary
+


### PR DESCRIPTION
Add a .gitattributes to attempt to specify the language as C++ on the master branch (this fixes the repository UI on GitHub and also resolves Issue #7)

In full disclosure, this addition takes inspiration from the following gitattributes file: https://github.com/alexkaratarakis/gitattributes/blob/master/C%2B%2B.gitattributes

Feel free to smplify it, but for what it's worth, this did appear to fix the language detection on my fork of the repo.

On another note: there's more with this came from :smile: 

I am hoping to analyze and/or work on this repo some more, because it interests me.

Miss you,

-chocorho