### PR TITLE
Refactor ostringstream object instantiation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,37 @@
+# Sources
+*.c     text diff=c
+*.cc    text diff=cpp
+*.cxx   text diff=cpp
+*.cpp   text diff=cpp
+*.c++   text diff=cpp
+*.hpp   text diff=cpp
+*.h     text diff=c
+*.h++   text diff=cpp
+*.hh    text diff=cpp
+
+# Compiled Object files
+*.slo   binary
+*.lo    binary
+*.o     binary
+*.obj   binary
+
+# Precompiled Headers
+*.gch   binary
+*.pch   binary
+
+# Compiled Dynamic libraries
+*.so    binary
+*.dylib binary
+*.dll   binary
+
+# Compiled Static libraries
+*.lai   binary
+*.la    binary
+*.a     binary
+*.lib   binary
+
+# Executables
+*.exe   binary
+*.out   binary
+*.app   binary
+

--- a/include/Console.hpp
+++ b/include/Console.hpp
@@ -74,24 +74,9 @@ namespace Blame {
         void flipBuffers() {
             this->has_flipped.exchange(true);
 
-            switch (this->current_buffer) {
-                case 0:
-                    std::cout << back_buffer.str();
-                    // Clear the buffer
-                    back_buffer.str(std::string());
-                    this->current_buffer = 1;
-                    break;
-
-                case 1:
-                    std::cout << front_buffer.str();
-                    // Clear the buffer
-                    front_buffer.str(std::string());
-                    this->current_buffer = 0;
-                    break;
-
-                default:
-                    break;
-            }
+            this->current_buffer = static_cast<buffer_t>((this->current_buffer + 1) % NUM_BUFFERS);
+            std::cout << buffer_list.at(this->current_buffer)->str();
+            buffer_list.at(this->current_buffer)->str(std::string());
 
             // this->setTitle(std::to_string(this->current_buffer));
         }
@@ -105,10 +90,13 @@ namespace Blame {
         std::vector<Blame::Widgets::Listener *> focus_order;
         Blame::Widgets::Listener *focused_widget;
 
+        enum buffer_t {
+          FRONT=0, BACK, NUM_BUFFERS
+        };
         std::ostringstream front_buffer;
         std::ostringstream back_buffer;
         std::vector<std::ostringstream *> buffer_list;
-        int current_buffer = 0;
+        buffer_t current_buffer = FRONT;
 
         std::atomic_bool has_flipped;
 

--- a/include/Console.hpp
+++ b/include/Console.hpp
@@ -93,8 +93,8 @@ namespace Blame {
         enum buffer_t {
           FRONT=0, BACK, NUM_BUFFERS
         };
-        std::ostringstream front_buffer;
-        std::ostringstream back_buffer;
+/*        std::ostringstream front_buffer;
+        std::ostringstream back_buffer;*/
         std::vector<std::ostringstream *> buffer_list;
         buffer_t current_buffer = FRONT;
 

--- a/src/main/cpp/Console.cpp
+++ b/src/main/cpp/Console.cpp
@@ -17,8 +17,10 @@ Blame::Console::Console() {
     this->moveCaret(std::cout, 0, 0);
     std::cout << Blame::Util::EscapeCodes::caretOff();
 
-    this->buffer_list.push_back(&front_buffer);
-    this->buffer_list.push_back(&back_buffer);
+    std::ostringstream *front_buffer = new std::ostringstream();
+    std::ostringstream *back_buffer = new std::ostringstream();
+    this->buffer_list.push_back(front_buffer);
+    this->buffer_list.push_back(back_buffer);
 
     this->exit.store(false);
     this->has_flipped.store(true);
@@ -58,6 +60,11 @@ Blame::Console::~Console() {
     term.c_lflag |= ECHO;
     term.c_lflag |= ICANON;
     tcsetattr(STDIN_FILENO, TCSANOW, &term);
+
+    /* TODO We still need to delete all the manually-allocated memory.
+     * Right?*/
+    delete buffer_list.at(FRONT);
+    delete buffer_list.at(BACK);
 }
 
 void Blame::Console::mainLoop() {


### PR DESCRIPTION
This is a possible way to simplify and remove unnecessary ostringstream objects from the console.

But in reality, it is also a way to test whether my GitHub webhook is working properly. I am less certain whether this PR is ready to be merged, but feel free to weigh in.